### PR TITLE
Shaving off another byte, with document.write

### DIFF
--- a/tron/tron.html
+++ b/tron/tron.html
@@ -1,1 +1,1 @@
-<body id=b onkeyup=e=event onload=z=c.getContext('2d');z.fillRect(s=0,0,n=150,x=11325);setInterval("0<x%n&x<n*n&(z[x+=[1,-n,-1,n][e.which&3]]^=1)?z.clearRect(x%n,x/n,1,1,s++):b.innerHTML='game over:'+s",9)><canvas id=c>
+<body onkeyup=e=event onload=z=c.getContext('2d');z.fillRect(s=0,0,n=150,x=11325);setInterval("0<x%n&x<n*n&(z[x+=[1,-n,-1,n][e.which&3]]^=1)?z.clearRect(x%n,x/n,1,1,s++):document.write('gameï¿½over:'+s)",9)><canvas id=c>


### PR DESCRIPTION
By using document.write to write the ending score the body doesn't need an id, overall saving a byte. The canvas is removed because the document.write is called after the page is loaded, implicitly calling document.open and creating a new page. 
