### PR TITLE
Update 2018-06-18-bootable_cd_from_scratch.html

### DIFF
--- a/_posts/2018/2018-06-18-bootable_cd_from_scratch.html
+++ b/_posts/2018/2018-06-18-bootable_cd_from_scratch.html
@@ -55,7 +55,7 @@ short.</p>
 <p>The Volume Descriptors are followed by the Boot Catalog. El Torito supports various emulation modes. The CD-ROM
 can emulate a bootable floppy, bootable harddrive, etc. I picked no emulation, which implies the BIOS will
 load a specific number of sectors and jump into our bootloader.</p>
-<p>The checksum is computed such that all 16-bit values in the record sum to 0 (mod 65535).</p>
+<p>The checksum is computed such that all 16-bit values in the record sum to 0 (mod 65536).</p>
 
 <p>First entry in the Boot Catalog (Validation Entry):</p>
 <pre>


### PR DESCRIPTION
Fix checksum definition - I believe the sum is just truncated to 16bit, so it is mod 2^16, not mod 2^16-1