### PR TITLE
Remove the GIF fallback

### DIFF
--- a/_posts/2018/2018-06-18-bootable_cd_from_scratch.html
+++ b/_posts/2018/2018-06-18-bootable_cd_from_scratch.html
@@ -175,6 +175,6 @@ TIMES 2048 - ($ - $$) db 0             ; Fill the rest of the sector with 0
 generate the tweet. Finally, I burned a CD and tested that things work on real
 hardware.</p>
 
-<video width="600" height="338" autoplay muted loop playsinline>
+<video width="600" height="338" style="max-width: 100%;" autoplay muted loop playsinline>
   <source src="/files/2018/bootable_cd_retro_game_tweet/it_works.mp4" type="video/mp4">
 </video>

--- a/_posts/2018/2018-06-18-bootable_cd_from_scratch.html
+++ b/_posts/2018/2018-06-18-bootable_cd_from_scratch.html
@@ -175,7 +175,6 @@ TIMES 2048 - ($ - $$) db 0             ; Fill the rest of the sector with 0
 generate the tweet. Finally, I burned a CD and tested that things work on real
 hardware.</p>
 
-<video width="600" height="338" autoplay muted loop>
+<video width="600" height="338" autoplay muted loop playsinline>
   <source src="/files/2018/bootable_cd_retro_game_tweet/it_works.mp4" type="video/mp4">
-  <img src="/files/2018/bootable_cd_retro_game_tweet/it_works.gif">
 </video>


### PR DESCRIPTION
because it is still being downloaded despite HTML5 video and [all modern browsers](https://caniuse.com/#feat=video) supports HTML5 video.